### PR TITLE
feat(visualisation): migrate from vtk to k3d visualisation

### DIFF
--- a/examples/subdivision_segmentation_view.py
+++ b/examples/subdivision_segmentation_view.py
@@ -52,6 +52,7 @@ def read_poses(
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(prog="StaticPipeline")
     parser.add_argument("--data_directory", type=str, required=True)
+    parser.add_argument("--filename", type=str, required=True)
     parser.add_argument("--diff", type=bool, required=False, default=False)
     args = parser.parse_args()
 
@@ -89,7 +90,7 @@ if __name__ == "__main__":
     )
     grid.subdivide(subdividers)
     grid.map_leaf_points(segmenter)
-    Visualiser.draw(grid=grid)
+    Visualiser.draw(grid=grid, filename=args.filename)
 
     if args.diff:
         random.seed(42)
@@ -99,4 +100,4 @@ if __name__ == "__main__":
         segmented_points_cloud.paint_uniform_color(
             [random.random(), random.random(), random.random()]
         )
-        o3d.visualization.draw(segmented_points_cloud)
+        o3d.visualization.draw(point_cloud + segmented_points_cloud)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ numpy==1.25.2
 open3d==0.17.0
 octreelib @ git+https://github.com/true-real-michael/octreelib@e458792a3fe5d3370a2bebd82349868f5d1cbb1a
 vtk~=9.2.6
+k3d==2.16.0

--- a/slam/utils/visualiser.py
+++ b/slam/utils/visualiser.py
@@ -1,103 +1,75 @@
-import vtk
+import k3d
+import numpy as np
 from octreelib.grid import StaticGrid
 from octreelib.octree import Octree, OctreeNode
 
+import itertools
 from typing import List
 
 __all__ = ["Visualiser"]
 
-from vtkmodules.vtkCommonColor import vtkNamedColors
-
 
 class Visualiser:
     @staticmethod
-    def draw(grid: StaticGrid):
-        actors = Visualiser.__grid_actors(grid)
-        Visualiser.__run_visualization(actors)
+    def draw(grid: StaticGrid, filename: str):
+        plot = k3d.Plot()
 
-    @staticmethod
-    def __visualize_octree(octree: Octree):
-        actors = Visualiser.__octree_actors(octree)
-        Visualiser.__run_visualization(actors)
-
-    @staticmethod
-    def __run_visualization(actors: List[vtk.vtkActor]):
-        renderer = vtk.vtkRenderer()
-        renderer.SetBackground(0.5, 0.6, 0.8)
-
-        for actor in actors:
-            renderer.AddActor(actor)
-
-        # Create a render window
-        render_window = vtk.vtkRenderWindow()
-        render_window.AddRenderer(renderer)
-        render_window.SetSize(1600, 1200)
-
-        # Create an interactor for user interaction
-        interactor = vtk.vtkRenderWindowInteractor()
-        interactor.SetRenderWindow(render_window)
-
-        # Create an interactor style for panning and rotating the view
-        style = vtk.vtkInteractorStyleTrackballCamera()
-        interactor.SetInteractorStyle(style)
-
-        # Start the interactor
-        interactor.Initialize()
-        interactor.Start()
-
-    @staticmethod
-    def __octree_actors(octree: Octree):
-        def octree_node_actors(node: OctreeNode):
-            if node.has_children:
-                return sum([octree_node_actors(child) for child in node.children], [])
-            bounds = [
-                node.bounding_box[0][0],
-                node.bounding_box[1][0],
-                node.bounding_box[0][1],
-                node.bounding_box[1][1],
-                node.bounding_box[0][2],
-                node.bounding_box[1][2],
-            ]
-            cube_source = vtk.vtkCubeSource()
-            cube_source.SetBounds(bounds)
-
-            cube_mapper = vtk.vtkPolyDataMapper()
-            cube_mapper.SetInputConnection(cube_source.GetOutputPort())
-
-            cube_actor = vtk.vtkActor()
-            cube_actor.SetMapper(cube_mapper)
-            cube_actor.GetProperty().SetRepresentationToWireframe()
-            cube_actor.GetProperty().SetLineWidth(2.0)
-
-            points = vtk.vtkPoints()
-            cells = vtk.vtkCellArray()
-            for point in node.points:
-                point_id = points.InsertNextPoint(point[:])
-                cells.InsertNextCell(1)
-                cells.InsertCellPoint(point_id)
-
-                points.Modified()
-                cells.Modified()
-
-            input_data = vtk.vtkPolyData()
-            input_data.SetPoints(points)
-            input_data.SetVerts(cells)
-
-            points_mapper = vtk.vtkPolyDataMapper()
-            points_mapper.SetInputData(input_data)
-
-            colors = vtkNamedColors()
-            points_actor = vtk.vtkActor()
-            points_actor.SetMapper(points_mapper)
-            points_actor.GetProperty().SetColor(colors.GetColor3d("Green"))
-            points_actor.GetProperty().SetPointSize(3)
-
-            return [cube_actor, points_actor]
-
-        return octree_node_actors(octree.root)
-
-    @staticmethod
-    def __grid_actors(grid: StaticGrid):
-        return sum(
-            [Visualiser.__octree_actors(octree) for octree in grid.octrees.values()], []
+        points = Visualiser.__get_points(grid)
+        plot += k3d.points(
+            positions=points,
+            point_size=0.1,
+            shader='3d',
         )
+
+        vertices = Visualiser.__get_voxels_vertices(grid)
+        for vertex in vertices:
+            plot += k3d.lines(
+                vertices=vertex,
+                indices=[
+                    [0, 2, 2, 6, 6, 4, 4, 0],  # Yeah, that's weird
+                    [0, 1, 1, 5, 5, 4, 4, 0],  # but I didn't invent other way
+                    [0, 1, 1, 3, 3, 2, 2, 0],  # to trace vertices
+                    [1, 3, 3, 7, 7, 5, 5, 1],
+                    [2, 3, 3, 7, 7, 6, 6, 2],
+                    [4, 5, 5, 7, 7, 6, 6, 4],
+                ],
+                width=0.01,
+                color=0xff0000,
+                indices_type="segment",
+            )
+
+        with open(filename, 'w') as f:
+            f.write(plot.get_snapshot())
+
+    @staticmethod
+    def __get_points(grid: StaticGrid) -> np.ndarray:
+        points = np.empty((0, 3))
+
+        for ind in range(len(grid.octrees.values())):
+            for point in grid.get_points(ind):
+                points = np.append(points, [point], axis=0)
+
+        return points
+
+    @staticmethod
+    def __get_voxels_vertices(grid: StaticGrid):
+        vertices = []
+        for octree in grid.octrees.values():
+            voxel_vertices = Visualiser.__get_octree_voxels(octree)
+            vertices.extend(voxel_vertices)
+
+        return np.asarray(vertices)
+
+    @staticmethod
+    def __get_octree_voxels(octree: Octree) -> List:
+        def get_children_bounds(node: OctreeNode) -> List:
+            corners = []
+            if node.has_children:
+                for child in node.children:
+                    corners.extend(get_children_bounds(child))
+
+                return corners
+
+            return [[node.corner + offset for offset in itertools.product([0, node.edge_length], repeat=3)]]
+
+        return get_children_bounds(octree.root)

--- a/slam/utils/visualiser.py
+++ b/slam/utils/visualiser.py
@@ -18,7 +18,7 @@ class Visualiser:
         plot += k3d.points(
             positions=points,
             point_size=0.1,
-            shader='3d',
+            shader="3d",
         )
 
         vertices = Visualiser.__get_voxels_vertices(grid)
@@ -34,11 +34,11 @@ class Visualiser:
                     [4, 5, 5, 7, 7, 6, 6, 4],
                 ],
                 width=0.01,
-                color=0xff0000,
+                color=0xFF0000,
                 indices_type="segment",
             )
 
-        with open(filename, 'w') as f:
+        with open(filename, "w") as f:
             f.write(plot.get_snapshot())
 
     @staticmethod
@@ -70,6 +70,11 @@ class Visualiser:
 
                 return corners
 
-            return [[node.corner + offset for offset in itertools.product([0, node.edge_length], repeat=3)]]
+            return [
+                [
+                    node.corner + offset
+                    for offset in itertools.product([0, node.edge_length], repeat=3)
+                ]
+            ]
 
         return get_children_bounds(octree.root)


### PR DESCRIPTION
Visualisation module was migrated from `vtk` library to `k3d` to achieve more dynamically and comfortable comparison of subdividions/segmentations/filters results.

Now, instead of downloading heavy libraries, you can just open `.html` file in your browser.