### PR TITLE
feat(subdivisions): add eigen_value and cape conditions

### DIFF
--- a/slam/segmenter/__init__.py
+++ b/slam/segmenter/__init__.py
@@ -1,8 +1,12 @@
+import slam.segmenter.cape as cape_module
+import slam.segmenter.count as count_module
 import slam.segmenter.identical as identical_module
 import slam.segmenter.ransac as ransac_module
 import slam.segmenter.segmenter as segmenter_module
+from slam.segmenter.cape import *
+from slam.segmenter.count import *
 from slam.segmenter.identical import *
 from slam.segmenter.ransac import *
 from slam.segmenter.segmenter import *
 
-__all__ = segmenter_module.__all__ + ransac_module.__all__ + identical_module.__all__
+__all__ = cape_module.__all__ + count_module.__all__ + segmenter_module.__all__ + ransac_module.__all__ + identical_module.__all__

--- a/slam/segmenter/__init__.py
+++ b/slam/segmenter/__init__.py
@@ -9,4 +9,5 @@ from slam.segmenter.identical import *
 from slam.segmenter.ransac import *
 from slam.segmenter.segmenter import *
 
-__all__ = cape_module.__all__ + count_module.__all__ + segmenter_module.__all__ + ransac_module.__all__ + identical_module.__all__
+__all__ = (cape_module.__all__ + count_module.__all__ + segmenter_module.__all__ +
+           ransac_module.__all__ + identical_module.__all__)

--- a/slam/segmenter/cape.py
+++ b/slam/segmenter/cape.py
@@ -1,0 +1,53 @@
+import numpy as np
+
+from slam.segmenter.segmenter import Segmenter
+from slam.typing import ArrayNx3
+
+__all__ = ["CAPESegmenter"]
+
+
+class CAPESegmenter(Segmenter):
+    """
+    Represents CAPE "max/min eigenvalues correlation" segmenter: if max_eigen_value/min_eigen_value > value
+    than this voxel considers as planar, otherwise it should be deleted.
+    More information: https://arxiv.org/pdf/1803.02380.pdf
+
+    Parameters
+    ----------
+    correlation: float
+        Lower bound of max/min eigen values correlation
+    """
+
+    def __init__(self, correlation: float) -> None:
+        self.__correlation: float = correlation
+
+    def __call__(self, points: ArrayNx3[float]) -> ArrayNx3[float]:
+        """
+        Represent count-based subdivider mechanism which returns True/False statement based on points count
+
+        Parameters
+        ----------
+        points: ArrayNx3[float]
+            Points of point cloud (or octree voxel)
+
+        Returns
+        -------
+        should_be_split: bool
+            Returns
+        """
+        if len(points) <= 10:
+            return []
+
+        converted_points = np.asarray(points)
+        standardized_data = (
+            converted_points - converted_points.mean(axis=0)
+        ) / converted_points.std(axis=0)
+        covariance_matrix = np.cov(standardized_data, ddof=1, rowvar=False)
+        eigenvalues, _ = np.linalg.eig(covariance_matrix)
+        decrease_order = np.argsort(eigenvalues)[::-1]
+        max_eigenvalue, _, min_eigenvalue = eigenvalues[decrease_order]
+
+        if max_eigenvalue / min_eigenvalue < self.__correlation:
+            return points
+
+        return []

--- a/slam/segmenter/cape.py
+++ b/slam/segmenter/cape.py
@@ -23,7 +23,7 @@ class CAPESegmenter(Segmenter):
 
     def __call__(self, points: ArrayNx3[float]) -> ArrayNx3[float]:
         """
-        Represent count-based subdivider mechanism which returns True/False statement based on points count
+        Represent CAPE planar condition.
 
         Parameters
         ----------
@@ -32,8 +32,8 @@ class CAPESegmenter(Segmenter):
 
         Returns
         -------
-        should_be_split: bool
-            Returns
+        segmented_points: ArrayNx3[float]
+            List of 3D segmented points after processing the CAPE condition
         """
         if len(points) <= 10:
             return []

--- a/slam/segmenter/count.py
+++ b/slam/segmenter/count.py
@@ -1,0 +1,40 @@
+from slam.segmenter import Segmenter
+from slam.typing import ArrayNx3
+
+__all__ = ["CountSegmenter"]
+
+
+class CountSegmenter(Segmenter):
+    """
+    TODO: move it to Filter condition.
+
+    Represents "number of points" filter: if there are less than N points in voxel,
+    it should be deleted.
+
+    Parameters
+    ----------
+    count: int
+        Lower bound number of points in given point cloud
+    """
+
+    def __init__(self, count: int) -> None:
+        self.__count = count
+
+    def __call__(self, points: ArrayNx3[float]) -> ArrayNx3[float]:
+        """
+        Represent count-based filter mechanism which returns identical points or empty array.
+
+        Parameters
+        ----------
+        points: ArrayNx3[float]
+            Points of point cloud (or octree voxel)
+
+        Returns
+        -------
+        segmented_points: ArrayNx3[float]
+            List of 3D segmented points after processing the count-filter
+        """
+        if len(points) <= self.__count:
+            return []
+
+        return points

--- a/slam/subdivider/__init__.py
+++ b/slam/subdivider/__init__.py
@@ -1,8 +1,10 @@
 import slam.subdivider.count as count_module
+import slam.subdivider.eigen_value as eigen_value_module
 import slam.subdivider.size as size_module
 import slam.subdivider.subdivider as subdivider_base_module
 from slam.subdivider.count import *
+from slam.subdivider.eigen_value import *
 from slam.subdivider.size import *
 from slam.subdivider.subdivider import *
 
-__all__ = count_module.__all__ + subdivider_base_module.__all__ + size_module.__all__
+__all__ = count_module.__all__ + eigen_value_module.__all__ + subdivider_base_module.__all__ + size_module.__all__

--- a/slam/subdivider/eigen_value.py
+++ b/slam/subdivider/eigen_value.py
@@ -1,0 +1,49 @@
+import numpy as np
+
+from slam.subdivider.subdivider import Subdivider
+from slam.typing import ArrayNx3
+
+__all__ = ["EigenValueSubdivider"]
+
+
+class EigenValueSubdivider(Subdivider):
+    """
+    Represents "PCA minimum eigen value" condition: if it is more than predefined
+    value, it should be split.
+
+    Parameters
+    ----------
+    value: float
+        Minimum value for eigen value
+    """
+
+    def __init__(self, value: float) -> None:
+        self.__value: float = value
+
+    def __call__(self, points: ArrayNx3[float]) -> bool:
+        """
+        Represent "eigen-value"-based subdivider mechanism which returns True/False statement based on points
+        PCA calculations
+
+        Parameters
+        ----------
+        points: ArrayNx3[float]
+            Points of point cloud (or octree voxel)
+
+        Returns
+        -------
+        should_be_split: bool
+            Returns False if minimum value of points covariance matrix less than predefined value, otherwise
+            returns True
+        """
+        if len(points) < 3:
+            return False
+
+        points = np.asarray(points)
+        standardized_data = (points - points.mean(axis=0)) / points.std(axis=0)
+        covariance_matrix = np.cov(standardized_data, ddof=1, rowvar=False)
+        eigenvalues, _ = np.linalg.eig(covariance_matrix)
+        decrease_order = np.argsort(eigenvalues)[::-1]
+        _, _, min_eigenvalue = eigenvalues[decrease_order]
+
+        return min_eigenvalue > self.__value


### PR DESCRIPTION
What was added:
1. `EigenValue` condition - returns True/False statement based on points PCA calculations.
2. `CAPE` segmenter condition - deletes voxel, if `max_eigen_value/min_eigen_value > value`
3. `Count` segmenter condition - deletes voxel, if `len(points) > count` (basically, this is kind of filter and will be moved in future)